### PR TITLE
allow any Symfony Response object

### DIFF
--- a/src/Vluzrmos/LumenCors/Middlewares/CorsMiddleware.php
+++ b/src/Vluzrmos/LumenCors/Middlewares/CorsMiddleware.php
@@ -5,6 +5,7 @@ namespace Vluzrmos\LumenCors\Middlewares;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 class CorsMiddleware
 {
@@ -33,18 +34,18 @@ class CorsMiddleware
         }
 
         $response = $next($request);
-        
+
         return $this->setCorsHeaders($response);
     }
 
     /**
-     * @param $response
-     * @return mixed
+     * @param SymfonyResponse $response
+     * @return SymfonyResponse
      */
-    public function setCorsHeaders($response)
+    public function setCorsHeaders(SymfonyResponse $response)
     {
         foreach ($this->headers as $key => $value) {
-            $response->header($key, $value);
+            $response->headers->set($key, $value);
         }
 
         return $response;


### PR DESCRIPTION
Hey there. I like your middleware, but can't use it because I have a case where I'm using `Laravel\Lumen\Http\ResponseFactory::download` to return a download response, which is an instance of `Symfony\Something\BinaryFileResponse`. Symfony Response objects don't have the `header()` method, which is added by Laravel, but is a simple passthrough to `$this->headers->set()`. 

So anyway, by using the parent class, you make this middleware more flexible, and typehinting the `SymfonyResponse` doesn't break anything because all `Illuminate\Http\Response` objects are instances of the parent Symfony object.
